### PR TITLE
Upgraded genai cdk as new KB bedrock indexes use faiss.

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "backend",
       "version": "0.1.0",
       "dependencies": {
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.78",
+        "@cdklabs/generative-ai-cdk-constructs": "^0.1.106",
         "@middy/core": "^5.2.4",
         "@middy/http-header-normalizer": "^5.2.4",
         "@middy/http-json-body-parser": "^5.2.4",
@@ -683,11 +683,11 @@
       "dev": true
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs": {
-      "version": "0.1.78",
-      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.78.tgz",
-      "integrity": "sha512-5OYGHPyGGBofyNSqbQ2YMKzDiKf1Uas2N61zKhNysh1qKNPbjq2chSJFOc2NQiuZOzNcUX3lzep24N1V0fQanA==",
+      "version": "0.1.106",
+      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.106.tgz",
+      "integrity": "sha512-Czx0yVt3EwKM0wa+hNHOoc+5rdf2TLDI1RhKjN19ChmypamMEW69WFfPl2SwlKpl9kuJtVJJ/Zlq584Rv9Ucyw==",
       "dependencies": {
-        "cdk-nag": "^2.28.46"
+        "cdk-nag": "^2.28.78"
       },
       "engines": {
         "node": ">= 18.12.0 <= 20.x"
@@ -2027,9 +2027,9 @@
       ]
     },
     "node_modules/cdk-nag": {
-      "version": "2.28.49",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.49.tgz",
-      "integrity": "sha512-LvnzMMqv26HxfjS14imjqGmuFxJTBM0c7K0s51aR+VVYz22+W79VOmFI9pPinP039PAbND/xMxD5glmVIZjsbw==",
+      "version": "2.28.81",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.81.tgz",
+      "integrity": "sha512-ulpuNHuiGjbUDzbdNJZg7w1Y4zl4+/0BuYli0KBsvo3vYDL+shkrz2bEG9QtVvD0H22Yj0lKNPDKSYPD3nGR0w==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.0.5"

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "typescript": "~5.3.3"
   },
   "dependencies": {
-    "@cdklabs/generative-ai-cdk-constructs": "^0.1.78",
+    "@cdklabs/generative-ai-cdk-constructs": "^0.1.106",
     "@middy/core": "^5.2.4",
     "@middy/http-header-normalizer": "^5.2.4",
     "@middy/http-json-body-parser": "^5.2.4",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/generative-ai-cdk-constructs/pull/350
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
