### PR TITLE
fix: add user-agent header for Bedrock KB API tracking

### DIFF
--- a/backend/lambda/query/index.js
+++ b/backend/lambda/query/index.js
@@ -4,6 +4,7 @@ const {
 } = require("@aws-sdk/client-bedrock-agent-runtime");
 
 const client = new BedrockAgentRuntimeClient({
+  customUserAgent: [["aws-samples-rag", "bedrock-kb"]],
   region: process.env.AWS_REGION,
 });
 


### PR DESCRIPTION
*Issue #, if available:*
  N/A — follow-up to #49 (merged)
  
  *Description of changes:*
  Adds `customUserAgent` to the `BedrockAgentRuntimeClient` configuration so Bedrock KB API calls are identifiable by source framework in
  service-side metrics.
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.