### PR TITLE
fix: correct IAM permission bedrock:AgenticRetrieve → bedrock:AgenticRetrieveStream

### DIFF
--- a/BEDROCK_MANAGED_KB.md
+++ b/BEDROCK_MANAGED_KB.md
@@ -27,7 +27,7 @@
 | USE_AGENTIC_RETRIEVAL | Enable agentic retrieval | true |
 
 ## SDK Requirements
-- boto3 >= 1.43 for managed search and agentic retrieval
+- boto3 >= 1.43.2 for managed search and agentic retrieval
 - aws-cdk-lib >= 2.170.0 for KB L1 constructs
 
 ## Required IAM Permissions
@@ -36,7 +36,7 @@
   "Effect": "Allow",
   "Action": [
     "bedrock:Retrieve",
-    "bedrock:AgenticRetrieve"
+    "bedrock:AgenticRetrieveStream"
   ],
   "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
 }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ aws bedrock-agent create-knowledge-base \
 
 The CDK stack in this project has been updated to support both managed and vector knowledge bases. Set `KNOWLEDGE_BASE_TYPE=MANAGED` in the Lambda environment to use managed retrieval.
 
-> **Note:** Managed KBs require `boto3 >= 1.43` for managed search and agentic retrieval.
+> **Note:** Managed KBs require `boto3 >= 1.43.2` for managed search and agentic retrieval.
 
 **Reranking options** for managed search: `MANAGED` (default — automatic), `NONE` (disable reranking), `CUSTOM` (your own Bedrock reranking model e.g. Cohere Rerank v3.5).
 
@@ -109,7 +109,7 @@ The CDK stack in this project has been updated to support both managed and vecto
   "Effect": "Allow",
   "Action": [
     "bedrock:Retrieve",
-    "bedrock:AgenticRetrieve"
+    "bedrock:AgenticRetrieveStream"
   ],
   "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
 }


### PR DESCRIPTION

  *Issue #, if available:*
  N/A — fixes incorrect IAM action name in docs from #49
  
  *Description of changes:*
  Corrects the IAM permission from `bedrock:AgenticRetrieve` to `bedrock:AgenticRetrieveStream` in BEDROCK_MANAGED_KB.md and README.md per the
  official AWS docs: https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic-retrieve.html
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your
  choice.
